### PR TITLE
Add hashcode to generating key strings

### DIFF
--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusCache.java
@@ -212,7 +212,7 @@ public class ArcusCache implements Cache, InitializingBean {
 	 * name 둘 중에 하나가 반드시 있어야 합니다. name과 prefix값이 모두 있다면 prefix 값을 사용합니다.
 	 * 
 	 * 키 생성 로직은 다음과 같습니다.
-	 * 
+	 *
 	 * serviceId + (prefix | name) + ":" + key.toString();
 	 * 
 	 * 만약 전체 키의 길이가 250자를 넘을 경우에는 key.toString() 대신 그 값을 MD5로 압축한 값을 사용합니다.
@@ -222,8 +222,20 @@ public class ArcusCache implements Cache, InitializingBean {
 	 */
 	public String createArcusKey(final Object key) {
 		Assert.notNull(key);
-		String keyString = key.toString();
-		String arcusKey = serviceId + name + ":" + keyString;
+		String keyString, arcusKey;
+
+		if(key instanceof ArcusStringKey) {
+			keyString = ((ArcusStringKey) key).getStringKey().replace(' ', '_') +
+							String.valueOf( ((ArcusStringKey) key).getHash());
+		} else if (key instanceof Integer) {
+			keyString = key.toString();
+		} else {
+			keyString = key.toString();
+			int hash = ArcusStringKey.light_hash(keyString);
+			keyString = keyString.replace(' ', '_') + String.valueOf(hash);
+		}
+
+		arcusKey = serviceId + name + ":" + keyString;
 		if (this.prefix != null) {
 			arcusKey = serviceId + prefix + ":" + keyString;
 		}

--- a/src/main/java/com/navercorp/arcus/spring/cache/ArcusStringKey.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/ArcusStringKey.java
@@ -1,0 +1,30 @@
+package com.navercorp.arcus.spring.cache;
+
+/**
+ * Created by iceru on 2016. 7. 11..
+ */
+public class ArcusStringKey {
+  public static int light_hash(String str) {
+    int hash = 7;
+    for(int i = 0; i < str.length(); i++) {
+      hash = hash * 31 + str.charAt(i);
+    }
+    return hash;
+  }
+
+  private String stringKey = null;
+  private int hash = 0;
+
+  public ArcusStringKey(String key, int hash) {
+    this.stringKey = key;
+    this.hash = hash;
+  }
+
+  public String getStringKey() {
+    return stringKey;
+  }
+
+  public int getHash() {
+    return hash;
+  }
+}

--- a/src/main/java/com/navercorp/arcus/spring/cache/StringKeyGenerator.java
+++ b/src/main/java/com/navercorp/arcus/spring/cache/StringKeyGenerator.java
@@ -35,6 +35,8 @@ public class StringKeyGenerator implements KeyGenerator {
 
     @Override
     public Object generate(Object target, Method method, Object... params) {
+        int paramHash = 0;
+        int hash = 0;
         StringBuilder keyBuilder = new StringBuilder();
         for (int i = 0, n = params.length; i < n; i++) {
             if (i > 0) {
@@ -42,8 +44,10 @@ public class StringKeyGenerator implements KeyGenerator {
             }
             if (params[i] != null) {
                 keyBuilder.append(params[i]);
+                paramHash = ArcusStringKey.light_hash(params[i].toString());
+                hash ^= paramHash;
             }
         }
-        return keyBuilder.toString();
+        return new ArcusStringKey(keyBuilder.toString(), hash);
     }
 }


### PR DESCRIPTION
Add key's hashcode using each param's hashcode at StringKeyGenerator,
Add whole key string's hashcode at ArcusCache.createArcusKey,
Add ArcusStringKey class to distinguish given key type.
Closes issue #4.